### PR TITLE
move ssl client setup to main context

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -562,7 +562,6 @@ const DiscordWs = struct {
     pub fn deinit(self: *DiscordWs) void {
         if (!self.is_dying) {
             self.is_dying = true;
-            self.ssl_tunnel.deinit();
         }
 
         self.heartbeat_thread.wait();
@@ -669,7 +668,6 @@ const DiscordWs = struct {
 
             if (!self.heartbeat_ack) {
                 self.is_dying = true;
-                self.ssl_tunnel.deinit();
                 return;
             }
 

--- a/src/request.zig
+++ b/src/request.zig
@@ -19,33 +19,35 @@ pub const SslTunnel = struct {
 
     pub const Stream = ssl.Stream(*std.fs.File.Reader, *std.fs.File.Writer);
 
-    pub fn init(args: struct {
+    pub fn connect(self: *SslTunnel, args: struct {
         allocator: *std.mem.Allocator,
-        pem: []const u8,
         host: [:0]const u8,
         port: u16 = 443,
-    }) !*SslTunnel {
-        const result = try args.allocator.create(SslTunnel);
-        errdefer args.allocator.destroy(result);
+    }) !void {
+        self.client = ssl.Client.init(self.x509.getEngine());
+        self.client.relocate();
+        try self.client.reset(args.host, false);
 
-        result.allocator = args.allocator;
+        self.tcp_conn = try std.net.tcpConnectToHost(args.allocator, args.host, args.port);
+        errdefer self.tcp_conn.close();
 
-        result.trust_anchor = ssl.TrustAnchorCollection.init(args.allocator);
+        self.tcp_reader = self.tcp_conn.reader();
+        self.tcp_writer = self.tcp_conn.writer();
+
+        self.conn = ssl.initStream(self.client.getEngine(), &self.tcp_reader, &self.tcp_writer);
+    }
+
+    pub fn init(allocator: *std.mem.Allocator, pem: []const u8) !*SslTunnel {
+        const result = try allocator.create(SslTunnel);
+        errdefer allocator.destroy(result);
+
+        result.allocator = allocator;
+
+        result.trust_anchor = ssl.TrustAnchorCollection.init(allocator);
         errdefer result.trust_anchor.deinit();
-        try result.trust_anchor.appendFromPEM(args.pem);
+        try result.trust_anchor.appendFromPEM(pem);
 
         result.x509 = ssl.x509.Minimal.init(result.trust_anchor);
-        result.client = ssl.Client.init(result.x509.getEngine());
-        result.client.relocate();
-        try result.client.reset(args.host, false);
-
-        result.tcp_conn = try std.net.tcpConnectToHost(args.allocator, args.host, args.port);
-        errdefer result.tcp_conn.close();
-
-        result.tcp_reader = result.tcp_conn.reader();
-        result.tcp_writer = result.tcp_conn.writer();
-
-        result.conn = ssl.initStream(result.client.getEngine(), &result.tcp_reader, &result.tcp_writer);
 
         return result;
     }
@@ -68,24 +70,22 @@ pub const Https = struct {
 
     pub fn init(args: struct {
         allocator: *std.mem.Allocator,
-        pem: []const u8,
         host: [:0]const u8,
         port: u16 = 443,
         method: []const u8,
         path: []const u8,
+        ssl_tunnel: *SslTunnel,
     }) !Https {
-        var ssl_tunnel = try SslTunnel.init(.{
+        try args.ssl_tunnel.connect(.{
             .allocator = args.allocator,
-            .pem = args.pem,
             .host = args.host,
             .port = args.port,
         });
-        errdefer ssl_tunnel.deinit();
 
         const buffer = try args.allocator.alloc(u8, 0x1000);
         errdefer args.allocator.free(buffer);
 
-        var client = hzzp.base.Client.create(buffer, ssl_tunnel.conn.inStream(), ssl_tunnel.conn.outStream());
+        var client = hzzp.base.Client.create(buffer, args.ssl_tunnel.conn.inStream(), args.ssl_tunnel.conn.outStream());
 
         try client.writeHead(args.method, args.path);
 
@@ -94,14 +94,13 @@ pub const Https = struct {
 
         return Https{
             .allocator = args.allocator,
-            .ssl_tunnel = ssl_tunnel,
+            .ssl_tunnel = args.ssl_tunnel,
             .buffer = buffer,
             .client = client,
         };
     }
 
     pub fn deinit(self: *Https) void {
-        self.ssl_tunnel.deinit();
         self.allocator.free(self.buffer);
         self.* = undefined;
     }


### PR DESCRIPTION
Addresses and possibly closes #7.  Also cleans up my last pr so that in that github auth is formatted only once.  

I'm not sure that the ssl_tunnel deinit strategy is 100% correct.  This pr required a change to `Https.deinit()`, removing its ` self.ssl_tunnel.deinit();` which prevents segfaults from happening (introduced by this pr).  I hope this doesn't mess with your recent updates related to `heartbeat_ack` and `is_dying` flags which call `ssl_tunnel.deinit()`.  

Let me know if you'd like me to change anything.  