### PR TITLE
Initial presence

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -666,7 +666,14 @@ const DiscordWs = struct {
             \\       "$os": "{1}",
             \\       "$browser": "{2}",
             \\       "$device": "{2}"
-            \\     }}
+            \\     }},
+            \\	   "presence": {{
+            \\	     "status": "online",
+            \\	     "activities": [{{
+            \\         "type": 0,
+            \\         "name": "%%666 or %%std.ArrayList"
+            \\	     }}]
+            \\	   }}
             \\   }}
             \\ }}
         ,

--- a/src/main.zig
+++ b/src/main.zig
@@ -653,6 +653,8 @@ const DiscordWs = struct {
             return error.MalformedHelloResponse;
         }
 
+        @setEvalBranchQuota(2000);
+
         // Identify
         // Intents are (default unprivileged set - typing intents)
         try result.printMessage(
@@ -667,13 +669,13 @@ const DiscordWs = struct {
             \\       "$browser": "{2}",
             \\       "$device": "{2}"
             \\     }},
-            \\	   "presence": {{
-            \\	     "status": "online",
-            \\	     "activities": [{{
-            \\         "type": 0,
-            \\         "name": "%%666 or %%std.ArrayList"
-            \\	     }}]
-            \\	   }}
+            \\     "presence": {{
+            \\       "status": "online",
+            \\       "activities": [{{
+            \\          "type": 0,
+            \\          "name": "examples: %%666 or %%std.ArrayList"
+            \\       }}]
+            \\     }}
             \\   }}
             \\ }}
         ,


### PR DESCRIPTION
You can set your custom status while identifying. Using it to show at least example usage of the bot, as we don't yet have a `help` command.

Related to #17. Does not close it as this status doesn't change periodically to show uptime or something else.